### PR TITLE
Fix to v1.1.0 Addresses Issue #14

### DIFF
--- a/3a_methodsMetadataGuide.md
+++ b/3a_methodsMetadataGuide.md
@@ -36,7 +36,7 @@ Fill in the [gas_exchange_methods_template file](templates/gas_exchange_methods_
 
 ---
 
-[experimentalManipulation*](#experimentalmanipulation)  | 
+[experimentalTreatment*](#experimentalTreatment)  | 
 [plantAge*](#plantage) | 
 [leafAge*](#leafage)
 
@@ -164,8 +164,8 @@ Fill in the [gas_exchange_methods_template file](templates/gas_exchange_methods_
 
 ---
 
-### experimentalManipulation
-|**Metadata Element**|experimentalManipulation|
+### experimentalTreatment
+|**Metadata Element**|experimentalTreatment|
 |:----------------------------------------------------|:----------------------------------------------------|
 |**Required, Recommended, or Optional**|`required`|
 |**Description**|Indicate if any samples were subject to a manipulation. For naturally grown plants, or cultivated plants with standard fertilizer and pesticide application across all samples, select "none". Provide further treatment details in methodsSupplements tables. |


### PR DESCRIPTION
### Description

- Modification made to v1.1.0 3a_methodsMetadataGuide.md file to address issue #14 as suggested by @msteckle, led by @regnans. 
- The “experimentalManipulation” term within the 3a_methodsMetadataGuide.md file was updated to be “experimentalTreatment” to be consistent with the methods metadata template.
- v1.1.0 release description draft has been updated to describe the change made.

Closes #14 